### PR TITLE
feat(core): add support for @recurse directive

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -158,7 +158,7 @@ All pagination methods are available for queries as well as nested edges.
 - `.offset(offset: number)`: node offset or amount of nodes to skip.
 - `.after(id: Uid)`: fetch nodes after the `id`.
 
-you can also use 
+you can also use
 ```typescript
 .withArgs(args: {
   first: number,
@@ -174,6 +174,7 @@ Query and Edge directives:
 
 Query only directives:
 - **ignoreReflex**
+- **recurse**
 
 Those directives are available on edge or query as a function, e.g.
 `edge.cascase()`.

--- a/packages/core/src/directive/directive-builder.ts
+++ b/packages/core/src/directive/directive-builder.ts
@@ -10,6 +10,7 @@ export interface DirectiveBuilderArgs {
   ignoreReflex: undefined;
   recurse: RecurseBuilder | undefined;
 }
+
 export class DirectiveBuilder<T extends keyof DirectiveBuilderArgs = any> {
   constructor(
     private name: T,

--- a/packages/core/src/directive/directive-builder.ts
+++ b/packages/core/src/directive/directive-builder.ts
@@ -2,13 +2,13 @@ import { Transformer } from '../utils';
 import { LogicalOperatorBuilder, OperatorBuilder } from '../operator';
 import { DirectiveArgs, Directive } from './directive';
 import { extractRefs } from '../ref';
-import { RecurseBuilder } from './recurse'
+import { RecurseBuilderArgs } from './recurse'
 
 export interface DirectiveBuilderArgs {
   filter: LogicalOperatorBuilder | OperatorBuilder;
   cascade: undefined;
   ignoreReflex: undefined;
-  recurse: RecurseBuilder | undefined;
+  recurse: RecurseBuilderArgs;
 }
 
 export class DirectiveBuilder<T extends keyof DirectiveBuilderArgs = any> {

--- a/packages/core/src/directive/directive-builder.ts
+++ b/packages/core/src/directive/directive-builder.ts
@@ -2,13 +2,14 @@ import { Transformer } from '../utils';
 import { LogicalOperatorBuilder, OperatorBuilder } from '../operator';
 import { DirectiveArgs, Directive } from './directive';
 import { extractRefs } from '../ref';
+import { RecurseBuilder } from './recurse'
 
 export interface DirectiveBuilderArgs {
   filter: LogicalOperatorBuilder | OperatorBuilder;
   cascade: undefined;
   ignoreReflex: undefined;
+  recurse: RecurseBuilder | undefined;
 }
-
 export class DirectiveBuilder<T extends keyof DirectiveBuilderArgs = any> {
   constructor(
     private name: T,

--- a/packages/core/src/directive/directive.ts
+++ b/packages/core/src/directive/directive.ts
@@ -1,10 +1,12 @@
 import { LogicalOperator, Operator } from '../operator';
 import { Param } from '../param';
+import { Recurse } from './recurse';
 
 export interface DirectiveArgs {
   filter: LogicalOperator | Operator;
   cascade: undefined;
   ignoreReflex: undefined;
+  recurse: Recurse | undefined;
 }
 
 export class Directive<T extends keyof DirectiveArgs = any> {

--- a/packages/core/src/directive/directive.ts
+++ b/packages/core/src/directive/directive.ts
@@ -1,12 +1,12 @@
 import { LogicalOperator, Operator } from '../operator';
-import { Param } from '../param';
-import { Recurse } from './recurse';
+import { isParamMap, Param } from '../param';
+import { RecurseArgs } from './recurse';
 
 export interface DirectiveArgs {
   filter: LogicalOperator | Operator;
   cascade: undefined;
   ignoreReflex: undefined;
-  recurse: Recurse | undefined;
+  recurse: RecurseArgs | undefined;
 }
 
 export class Directive<T extends keyof DirectiveArgs = any> {
@@ -22,13 +22,37 @@ export class Directive<T extends keyof DirectiveArgs = any> {
   params(): Param[] {
     if (!this.hasArgs()) return [];
 
+    if (isParamMap(this.args)) {
+      return Object.values(this.args)
+    }
+
     return Array.isArray(this.args)
+        // Assumes args is a array of objects which have a "params" method which returns Param[]
       ? this.args.reduce((r, x) => [...r, ...x.params()], [])
+       // Assumes args has a "params" method which returns Param[]
+       // @ts-expect-error
       : this.args.params();
+
+    // TODO: The assumptions above are not type safe. We need an interface that defines a params() method which returns Param[].
+    // this.args should then be contrained by a type which unites the above and ParamMap.
   }
 
   toString() {
-    return '@' + this.name
-      + (this.hasArgs() ? `(${this.args})` : '');
+    const out = '@' + this.name
+
+    if (!this.hasArgs()) {
+      return out
+    }
+
+    if (isParamMap(this.args)) {
+      return this.params().reduce((p, c, i) => {
+          if (i > 0) {
+            p += ', '
+          }
+          return p += `${c.getName()}: ${c.getValue()}`
+        }, out + '(') + ')'
+    }
+
+    return out + `(${this.args})`
   }
 }

--- a/packages/core/src/directive/directive.ts
+++ b/packages/core/src/directive/directive.ts
@@ -45,11 +45,11 @@ export class Directive<T extends keyof DirectiveArgs = any> {
     }
 
     if (isParamMap(this.args)) {
-      return this.params().reduce((p, c, i) => {
+      return Object.keys(this.args).reduce((p, c, i) => {
           if (i > 0) {
             p += ', '
           }
-          return p += `${c.getName()}: ${c.getValue()}`
+          return p += `${c}: ${this.args[c].toString()}`
         }, out + '(') + ')'
     }
 

--- a/packages/core/src/directive/index.ts
+++ b/packages/core/src/directive/index.ts
@@ -1,3 +1,2 @@
 export * from './directive-builder';
 export * from './directive';
-export { RecurseBuilder } from './recurse';

--- a/packages/core/src/directive/index.ts
+++ b/packages/core/src/directive/index.ts
@@ -1,2 +1,3 @@
 export * from './directive-builder';
 export * from './directive';
+export { RecurseBuilder } from './recurse';

--- a/packages/core/src/directive/recurse.ts
+++ b/packages/core/src/directive/recurse.ts
@@ -1,51 +1,12 @@
 
-import { Param, ParamType } from '../param';
+import { Param, ParamBuilder } from '../param';
 
-export type RecurseBuilderArgs = {
-  loop?: boolean;
-  depth?: number;
+export type RecurseBuilderArgs = undefined | {
+  loop?: boolean | ParamBuilder<'boolean'>;
+  depth?: number | ParamBuilder<'int'>;
 }
 
-export class RecurseBuilder {
-  constructor(private args: RecurseBuilderArgs) { }
-
-  build() {
-    return new Recurse(this.args)
-  }
-}
-
-export class Recurse {
-  private ps: Param[]
-
-  constructor(args: RecurseBuilderArgs) {
-    this.ps = []
-    for (const k in args) {
-      if (!args[k]) {
-        continue;
-      }
-      let t: ParamType
-      switch (k) {
-        case 'loop':
-          t = 'boolean';
-          break;
-        case 'depth':
-          t = 'int';
-          break;
-      }
-      this.ps.push(new Param(k, t, args[k]))
-    }
-  }
-
-  params(): Param[] {
-    return this.ps;
-  }
-
-  toString() {
-    return this.ps.reduce((p, c) => {
-      if (p) {
-        p += ', '
-      }
-      return p += `${c.getName()}: ${c.getValue()}`
-    }, '')
-  }
+export type RecurseArgs = undefined | {
+  loop?: boolean | Param<'boolean'>;
+  depth?: number | Param<'int'>;
 }

--- a/packages/core/src/directive/recurse.ts
+++ b/packages/core/src/directive/recurse.ts
@@ -1,8 +1,11 @@
 
 import { Param, ParamBuilder } from '../param';
 
+// @see https://dgraph.io/docs/query-language/recurse-query/
 export type RecurseBuilderArgs = undefined | {
+  // The loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
   loop?: boolean | ParamBuilder<'boolean'>;
+  // the maximum depth to recurse.
   depth?: number | ParamBuilder<'int'>;
 }
 

--- a/packages/core/src/directive/recurse.ts
+++ b/packages/core/src/directive/recurse.ts
@@ -1,0 +1,53 @@
+
+import { Param, ParamType } from '../param';
+
+export type RecurseBuilderArgs = {
+  // The loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
+  loop?: boolean;
+  // the maximum depth to recurse.
+  depth?: number;
+}
+
+export class RecurseBuilder {
+  constructor(private args: RecurseBuilderArgs) { }
+
+  build() {
+    return new Recurse(this.args)
+  }
+}
+
+export class Recurse {
+  private ps: Param[]
+
+  constructor(args: RecurseBuilderArgs) {
+    this.ps = []
+    for (const k in args) {
+      if (!args[k]) {
+        continue;
+      }
+      let t: ParamType
+      switch (k) {
+        case 'loop':
+          t = 'boolean';
+          break;
+        case 'depth':
+          t = 'int';
+          break;
+      }
+      this.ps.push(new Param(k, t, args[k]))
+    }
+  }
+
+  params(): Param[] {
+    return this.ps;
+  }
+
+  toString() {
+    return this.ps.reduce((p, c) => {
+      if (p) {
+        p += ', '
+      }
+      return p += `${c.getName()}: ${c.getValue()}`
+    }, '')
+  }
+}

--- a/packages/core/src/directive/recurse.ts
+++ b/packages/core/src/directive/recurse.ts
@@ -2,9 +2,7 @@
 import { Param, ParamType } from '../param';
 
 export type RecurseBuilderArgs = {
-  // The loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
   loop?: boolean;
-  // the maximum depth to recurse.
   depth?: number;
 }
 

--- a/packages/core/src/edge/edge-builder.ts
+++ b/packages/core/src/edge/edge-builder.ts
@@ -231,16 +231,6 @@ export class EdgeBuilder extends FieldBuilder {
     return this;
   }
 
-  /**
-   * @see https://dgraph.io/docs/query-language/recurse-query/
-   * @param loopThe loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
-   * @param depth the maximum depth to recurse.
-   */
-  recurse(loop?: boolean, depth?: number) {
-    this.directives.recurse = new DirectiveBuilder('recurse', loop || depth ?  new RecurseBuilder({ loop, depth }) : undefined);
-    return this;
-  }
-
   keyToField(key: string) {
     if (['id', 'uid'].includes(key))
       return 'uid';

--- a/packages/core/src/edge/edge-builder.ts
+++ b/packages/core/src/edge/edge-builder.ts
@@ -231,6 +231,11 @@ export class EdgeBuilder extends FieldBuilder {
     return this;
   }
 
+  /**
+   * @see https://dgraph.io/docs/query-language/recurse-query/
+   * @param loopThe loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
+   * @param depth the maximum depth to recurse.
+   */
   recurse(loop?: boolean, depth?: number) {
     this.directives.recurse = new DirectiveBuilder('recurse', loop || depth ?  new RecurseBuilder({ loop, depth }) : undefined);
     return this;

--- a/packages/core/src/edge/edge-builder.ts
+++ b/packages/core/src/edge/edge-builder.ts
@@ -6,7 +6,7 @@ import {
   LogicalOperatorBuilder,
   OpArg,
 } from '../operator';
-import { Param, ParamBuilder, ParamMap, paramNameGen, ParamNameGen, ParamType } from '../param';
+import { ParamBuilder, ParamMap, paramNameGen, ParamNameGen, ParamType } from '../param';
 import { Edge } from './edge';
 import {
   capitalize,
@@ -326,8 +326,9 @@ export class EdgeBuilder extends FieldBuilder {
             if (typeof args  === 'object') {
               const r: ParamMap = {}
               for(const k in args) {
+                let p: ParamBuilder
                 if (args[k] instanceof ParamBuilder) {
-                  r[k] = args[k].build()
+                  p = args[k];
                 } else {
                   let t: ParamType
                   switch (k) {
@@ -337,11 +338,17 @@ export class EdgeBuilder extends FieldBuilder {
                     case 'depth':
                       t = 'int';
                       break;
+                    default:
+                      throw new Error(`Directive arg named parameter "${k}" not supported.`);
                   }
-                  r[k] = new Param(k, t, args[k])
+
+                  p = new ParamBuilder(t, args[k], k);
                 }
+
+                r[k] = p.build();
               }
-              return r
+
+              return r;
             }
 
             throw Error('directive builder args type not supported.');

--- a/packages/core/src/param/param.ts
+++ b/packages/core/src/param/param.ts
@@ -13,6 +13,12 @@ export interface ParamTypeValue {
 
 export type ParamType = keyof ParamTypeValue;
 export type ParamMap = { [name: string]: Param };
+export function isParamMap(v: any): v is ParamMap {
+  if (typeof v === 'object') {
+    return Object.values(v).every(i => i instanceof Param)
+  }
+  return false;
+}
 
 export class Param<
   T extends ParamType = any,

--- a/packages/core/src/param/param.ts
+++ b/packages/core/src/param/param.ts
@@ -15,7 +15,7 @@ export type ParamType = keyof ParamTypeValue;
 export type ParamMap = { [name: string]: Param };
 export function isParamMap(v: any): v is ParamMap {
   if (typeof v === 'object') {
-    return Object.values(v).every(i => i instanceof Param)
+    return Object.values(v).every(i => i instanceof Param);
   }
   return false;
 }

--- a/packages/core/src/query/query-builder.ts
+++ b/packages/core/src/query/query-builder.ts
@@ -8,7 +8,7 @@ import {
 import { ArgsBuilderData } from '../args';
 import { buildNameGen, BuildNameGen } from '../utils';
 import { Query } from './query';
-import { DirectiveBuilder, RecurseBuilder } from '../directive';
+import { DirectiveBuilder } from '../directive';
 import { Ref } from '../ref';
 import { CombinedQuery } from './combined-query';
 import { CombinedQueryBuilder } from './combined-query-builder';
@@ -54,11 +54,12 @@ export class QueryBuilder extends EdgeBuilder {
 
   /**
    * @see https://dgraph.io/docs/query-language/recurse-query/
-   * @param loopThe loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
-   * @param depth the maximum depth to recurse.
+   * @param args
+   * @param args.loop The loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
+   * @param args.depth the maximum depth to recurse.
    */
-  recurse(loop?: boolean, depth?: number) {
-    this.directives.recurse = new DirectiveBuilder('recurse', loop || depth ? new RecurseBuilder({ loop, depth }) : undefined);
+  recurse(args?: {loop?: boolean; depth?: number}) {
+    this.directives.recurse = new DirectiveBuilder('recurse', args);
     return this;
   }
 

--- a/packages/core/src/query/query-builder.ts
+++ b/packages/core/src/query/query-builder.ts
@@ -12,6 +12,7 @@ import { DirectiveBuilder } from '../directive';
 import { Ref } from '../ref';
 import { CombinedQuery } from './combined-query';
 import { CombinedQueryBuilder } from './combined-query-builder';
+import { RecurseBuilderArgs } from '../directive/recurse';
 
 type QueryProjection = EdgeBuilder | RawProjection;
 export type BuildQueryNameGen = BuildNameGen<{ _queryNameGenBrand: symbol }>;
@@ -52,13 +53,7 @@ export class QueryBuilder extends EdgeBuilder {
     return this;
   }
 
-  /**
-   * @see https://dgraph.io/docs/query-language/recurse-query/
-   * @param args
-   * @param args.loop The loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
-   * @param args.depth the maximum depth to recurse.
-   */
-  recurse(args?: {loop?: boolean; depth?: number}) {
+  recurse(args?: RecurseBuilderArgs) {
     this.directives.recurse = new DirectiveBuilder('recurse', args);
     return this;
   }

--- a/packages/core/src/query/query-builder.ts
+++ b/packages/core/src/query/query-builder.ts
@@ -8,7 +8,7 @@ import {
 import { ArgsBuilderData } from '../args';
 import { buildNameGen, BuildNameGen } from '../utils';
 import { Query } from './query';
-import { DirectiveBuilder } from '../directive';
+import { DirectiveBuilder, RecurseBuilder } from '../directive';
 import { Ref } from '../ref';
 import { CombinedQuery } from './combined-query';
 import { CombinedQueryBuilder } from './combined-query-builder';
@@ -49,6 +49,16 @@ export class QueryBuilder extends EdgeBuilder {
 
   ignoreReflex() {
     this.directives.ignoreReflex = new DirectiveBuilder('ignoreReflex', undefined);
+    return this;
+  }
+
+  /**
+   * @see https://dgraph.io/docs/query-language/recurse-query/
+   * @param loopThe loop parameter can be set to false, in which case paths which lead to a loop would be ignored while traversing.
+   * @param depth the maximum depth to recurse.
+   */
+  recurse(loop?: boolean, depth?: number) {
+    this.directives.recurse = new DirectiveBuilder('recurse', loop || depth ? new RecurseBuilder({ loop, depth }) : undefined);
     return this;
   }
 

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -16,4 +16,19 @@ describe('Directive test', () => {
     expect(query().ignoreReflex().toString())
       .toMatch(/@ignoreReflex \{/);
   });
+
+  it('`@recurse` directive no args', () => {
+    expect(edge({}).recurse().toString())
+      .toMatch(/@recurse \{/);
+  });
+
+  it('`@recurse` directive single arg', () => {
+    expect(edge({}).recurse(true).toString())
+      .toMatch(/@recurse\(loop: true\) \{/);
+  });
+
+  it('`@recurse` directive all args', () => {
+    expect(edge({}).recurse(true, 5).toString())
+      .toMatch(/@recurse\(loop: true, depth: 5\) \{/);
+  });
 });

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -23,12 +23,12 @@ describe('Directive test', () => {
   });
 
   it('`@recurse` directive single arg', () => {
-    expect(query().recurse(true).toString())
-      .toMatch(/@recurse\(loop: true\) \{/);
+    expect(query().recurse({ loop: false }).toString())
+      .toMatch(/@recurse\(loop: false\) \{/);
   });
 
   it('`@recurse` directive all args', () => {
-    expect(query().recurse(true, 5).toString())
-      .toMatch(/@recurse\(loop: true, depth: 5\) \{/);
+    expect(query().recurse({ loop: false, depth: 5 }).toString())
+      .toMatch(/@recurse\(loop: false, depth: 5\) \{/);
   });
 });

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -18,17 +18,17 @@ describe('Directive test', () => {
   });
 
   it('`@recurse` directive no args', () => {
-    expect(edge({}).recurse().toString())
+    expect(query().recurse().toString())
       .toMatch(/@recurse \{/);
   });
 
   it('`@recurse` directive single arg', () => {
-    expect(edge({}).recurse(true).toString())
+    expect(query().recurse(true).toString())
       .toMatch(/@recurse\(loop: true\) \{/);
   });
 
   it('`@recurse` directive all args', () => {
-    expect(edge({}).recurse(true, 5).toString())
+    expect(query().recurse(true, 5).toString())
       .toMatch(/@recurse\(loop: true, depth: 5\) \{/);
   });
 });

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { query, edge } from '../src';
 import { has } from '../src/operators';
 import { ParamBuilder } from '../src/param';
@@ -24,13 +25,20 @@ describe('Directive test', () => {
   });
 
   it('`@recurse` directive single primitive arg', () => {
-    expect(query().recurse({ loop: false }).toString())
-      .toMatch(/@recurse\(loop: false\) \{/);
+    const q = query().recurse({ loop: false });
+    expect(q.toString())
+      .toMatch(/@recurse\(loop: \$loop\) \{/);
+    const params = q.build().params();
+    expect(params[0].getValue()).toEqual('false');
   });
 
   it('`@recurse` directive all primitive args', () => {
-    expect(query().recurse({ loop: false, depth: 5 }).toString())
-      .toMatch(/@recurse\(loop: false, depth: 5\) \{/);
+    const q = query().recurse({ loop: false, depth: 5 });
+    expect(q.toString())
+      .toMatch(/@recurse\(loop: \$loop\, depth: \$depth\) \{/);
+    const params = q.build().params();
+    expect(params[0].getValue()).toEqual('false');
+    expect(params[1].getValue()).toEqual('5');
   });
 
   it('`@recurse` directive single ParamBuilder arg', () => {
@@ -41,4 +49,12 @@ describe('Directive test', () => {
     expect(myQuery.toString()).toMatch(/@recurse\(loop: \$loop\) \{/);
   });
 
+  it('`@recurse` directive all ParamBuilder args', () => {
+    const q = query().recurse({ loop: new ParamBuilder('boolean', false, 'loop'), depth: new ParamBuilder('int', 5, 'depth') });
+    expect(q.toString())
+      .toMatch(/@recurse\(loop: \$loop\, depth: \$depth\) \{/);
+    const params = q.build().params();
+    expect(params[0].getValue()).toEqual('false');
+    expect(params[1].getValue()).toEqual('5');
+  });
 });

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -1,5 +1,6 @@
 import { query, edge } from '../src';
 import { has } from '../src/operators';
+import { ParamBuilder } from '../src/param';
 
 // does not test formatting
 describe('Directive test', () => {
@@ -22,13 +23,22 @@ describe('Directive test', () => {
       .toMatch(/@recurse \{/);
   });
 
-  it('`@recurse` directive single arg', () => {
+  it('`@recurse` directive single primitive arg', () => {
     expect(query().recurse({ loop: false }).toString())
       .toMatch(/@recurse\(loop: false\) \{/);
   });
 
-  it('`@recurse` directive all args', () => {
+  it('`@recurse` directive all primitive args', () => {
     expect(query().recurse({ loop: false, depth: 5 }).toString())
       .toMatch(/@recurse\(loop: false, depth: 5\) \{/);
   });
+
+  it('`@recurse` directive single ParamBuilder arg', () => {
+    const myQuery = query().recurse({ loop: new ParamBuilder('boolean', false, 'loop') }).build();
+    const myParams = myQuery.params();
+
+    expect(myParams[0].getValue()).toEqual('false');
+    expect(myQuery.toString()).toMatch(/@recurse\(loop: \$loop\) \{/);
+  });
+
 });


### PR DESCRIPTION
Addresses #13 

This is a first pass at a solution:

Details:

1. Implements recurse as a query function since docs state that ["You can specify only one level of predicates after root. These would be traversed recursively. Both scalar and entity-nodes are treated similarly."](https://dgraph.io/docs/query-language/recurse-query/)
2. Tried to follow the builder pattern 
3. Tests included


