### PR TITLE
feat(core): support groupBy directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+.idea

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -171,6 +171,7 @@ you can also use
 
 Query and Edge directives:
 - **cascade**
+- **groupBy**
 
 Query only directives:
 - **ignoreReflex**

--- a/packages/core/src/directive/directive-builder.ts
+++ b/packages/core/src/directive/directive-builder.ts
@@ -3,12 +3,14 @@ import { OpBuilderTypes } from '../operator';
 import { DirectiveArgs, Directive } from './directive';
 import { extractRefs } from '../ref';
 import { RecurseBuilderArgs } from './recurse'
+import { GroupByBuilderArgs } from './group-by'
 
 export interface DirectiveBuilderArgs {
   filter: [OpBuilderTypes];
   cascade: undefined;
   ignoreReflex: undefined;
   recurse: RecurseBuilderArgs;
+  groupBy: GroupByBuilderArgs;
 }
 
 export class DirectiveBuilder<T extends keyof DirectiveBuilderArgs = keyof DirectiveBuilderArgs> {

--- a/packages/core/src/directive/directive.ts
+++ b/packages/core/src/directive/directive.ts
@@ -1,12 +1,14 @@
 import { LogicalOperator, Operator } from '../operator';
 import { Param } from '../param';
 import { RecurseArgs } from './recurse';
+import { GroupByArgs } from './group-by';
 
 export interface DirectiveArgs {
   filter: LogicalOperator | Operator;
   cascade: undefined;
   ignoreReflex: undefined;
   recurse: RecurseArgs | undefined;
+  groupBy: GroupByArgs;
 }
 
 export class Directive<T extends keyof DirectiveArgs = any> {
@@ -22,6 +24,7 @@ export class Directive<T extends keyof DirectiveArgs = any> {
   params(): Param[] {
     const argsValues = !this.hasArgs() ? []
     : Array.isArray(this.args) ? this.args
+    : typeof this.args!=='object'? [this.args]
     : Object.entries(this.args).map(([_, value]) => value);
 
     return argsValues.reduce((r, arg) => {
@@ -36,6 +39,7 @@ export class Directive<T extends keyof DirectiveArgs = any> {
   toString() {
     const argsList = !this.hasArgs() ? []
       : Array.isArray(this.args) ? this.args
+      : typeof this.args!=='object'? [this.args]
       : Object.entries(this.args).map(([key, value]) => `${key}: ${value}`);
 
     return `@${this.name}${

--- a/packages/core/src/directive/directive.ts
+++ b/packages/core/src/directive/directive.ts
@@ -42,7 +42,7 @@ export class Directive<T extends keyof DirectiveArgs = any> {
       : typeof this.args!=='object'? [this.args]
       : Object.entries(this.args).map(([key, value]) => `${key}: ${value}`);
 
-    return `@${this.name}${
+    return `@${this.name.toLowerCase()}${
       !argsList.length ? '' : `(${argsList.join(', ')})`
     }`;
   }

--- a/packages/core/src/directive/group-by.ts
+++ b/packages/core/src/directive/group-by.ts
@@ -1,0 +1,8 @@
+
+import { Param, ParamBuilder } from '../param';
+
+/** @see https://dgraph.io/docs/query-language/groupby/ */
+// predicate
+export type GroupByBuilderArgs = string | ParamBuilder<'string'>
+
+export type GroupByArgs = string | Param<'string'>;

--- a/packages/core/src/edge/edge-builder.ts
+++ b/packages/core/src/edge/edge-builder.ts
@@ -17,6 +17,7 @@ import {
   GenericProjection,
 } from './common';
 import { DirectiveBuilder } from '../directive';
+import { GroupByBuilderArgs } from '../directive/group-by';
 import { Ref } from '../ref';
 import { Runnable } from '../types';
 import {
@@ -244,6 +245,11 @@ export class EdgeBuilder extends FieldBuilder {
 
   cascade() {
     this.directives.cascade = new DirectiveBuilder('cascade', undefined);
+    return this;
+  }
+
+  groupBy(predicate: GroupByBuilderArgs) {
+    this.directives.groupBy = new DirectiveBuilder('groupBy', predicate);
     return this;
   }
 

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -51,4 +51,9 @@ describe('Directive test', () => {
     expect(myParams[0].getValue()).toEqual('false');
     expect(myParams[1].getValue()).toEqual('5');
   });
+
+  it('`@groupBy` directive', () => {
+    expect(edge({}).groupBy('predicate').toString())
+        .toMatch(/@groupBy\(predicate\) \{/);
+  });
 });

--- a/packages/core/test/directive.test.ts
+++ b/packages/core/test/directive.test.ts
@@ -15,7 +15,7 @@ describe('Directive test', () => {
 
   it('`@ignoreReflex` directive', () => {
     expect(query().ignoreReflex().toString())
-      .toMatch(/@ignoreReflex \{/);
+      .toMatch(/@ignorereflex \{/);
   });
 
   it('`@recurse` directive no args', () => {
@@ -54,6 +54,6 @@ describe('Directive test', () => {
 
   it('`@groupBy` directive', () => {
     expect(edge({}).groupBy('predicate').toString())
-        .toMatch(/@groupBy\(predicate\) \{/);
+        .toMatch(/@groupby\(predicate\) \{/);
   });
 });


### PR DESCRIPTION
Hi, thanks for the query builder. Just try to implement groupBy directive as it's needed in my application. Let me know if you need any changes. Cheers.

changes:
- add groupBy in core/directive
- add a groupBy method in edge-builder
- add test
- add doc
- all directives should be lowercase, see https://dgraph.io/docs/query-language/ignorereflex-directive/ and https://dgraph.io/docs/query-language/groupby/

fix #6